### PR TITLE
Add Unix-alikes to os_index

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -210,7 +210,7 @@ win_app_dir = function(..., error = TRUE) {
   file.path(d, ...)
 }
 
-os_index = if (is_windows()) 1 else if (is_linux()) 2 else if (is_macos()) 3 else 0
+os_index = if (is_windows()) 1 else if (is_unix()) 2 else if (is_macos()) 3 else 0
 
 default_inst = function() switch(
   os_index, win_app_dir('TinyTeX'), '~/.TinyTeX', '~/Library/TinyTeX'


### PR DESCRIPTION
Before the last commit added 'else 0', tinytex worked fine on Unix-alikes like FreeBSD. With 'is_unix()' FreeBSD is back again. 

I am not sure about the behaviour for Linux (is_unix should work here) and MacOS (now already recognized by is_unix?). Unfortunately I have no possibility to test with Linux and MacOS.